### PR TITLE
add required baseline

### DIFF
--- a/src/main/scala/scoverage/ScoverageSbtPlugin.scala
+++ b/src/main/scala/scoverage/ScoverageSbtPlugin.scala
@@ -206,13 +206,20 @@ object ScoverageSbtPlugin extends AutoPlugin {
                                log: Logger) {
 
     def statsKeyValue(key: String, value: Int): String = s"##teamcity[buildStatisticValue key='$key' value='$value']"
-
+    //having statement count is not enough, need to provide lines, teamcity will not produce
+    //the correct result
     // Log statement coverage as per: https://devnet.jetbrains.com/message/5467985
+    val linesCovered = coverage.files.foldLeft(0)((i, c) => i + c.loc)
+
+    log.info(statsKeyValue("CodeCoverageAbsLCovered", coverage.loc))
+    log.info(statsKeyValue("CodeCoverageAbsLTotal", 10000)) //value fixed for test
+
     log.info(statsKeyValue("CodeCoverageAbsSCovered", coverage.invokedStatementCount))
     log.info(statsKeyValue("CodeCoverageAbsSTotal", coverage.statementCount))
 
-    // Log branch coverage as a custom metrics (in percent)
-    log.info(statsKeyValue("CodeCoverageBranch", "%.0f".format(coverage.branchCoveragePercent).toInt))
+    // Log branch coverage exist (no need to use custom
+    log.info(statsKeyValue("CodeCoverageAbsBCovered", coverage.invokedBranchesCount))
+    log.info(statsKeyValue("CodeCoverageAbsBTotal", coverage.branchCount)
 
     // Create the coverage report for teamcity (HTML files)
     if (createCoverageZip)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.1-SNAPSHOT"
+version in ThisBuild := "1.5.2-TEAMCITY"


### PR DESCRIPTION
teamcity does not produce the coverage widget in build overview screen if the build does not report the number of lines coveraged and total number of lines 

there is a built-in static value for Blocks